### PR TITLE
Implement real-time fleet ETA

### DIFF
--- a/backend/pkg/handlers.go
+++ b/backend/pkg/handlers.go
@@ -90,10 +90,8 @@ func FleetOrderHandler(app *pocketbase.PocketBase) echo.HandlerFunc {
 			})
 		}
 
-		// Calculate ETA (12 ticks travel time = 2 minutes at 6 ticks/minute)
-		currentTick := tick.GetCurrentTick(app)
-		travelTime := int64(12)
-		etaTick := currentTick + travelTime
+                // Calculate ETA (2 minutes travel time)
+                eta := time.Now().Add(2 * time.Minute)
 
 		// Create fleet record
 		fleetCollection, err := app.Dao().FindCollectionByNameOrId("fleets")
@@ -105,10 +103,10 @@ func FleetOrderHandler(app *pocketbase.PocketBase) echo.HandlerFunc {
 
 		fleet := models.NewRecord(fleetCollection)
 		fleet.Set("owner_id", user.Id)
-		fleet.Set("from_id", req.FromID)
-		fleet.Set("to_id", req.ToID)
-		fleet.Set("eta_tick", etaTick)
-		fleet.Set("strength", req.Strength)
+                fleet.Set("from_id", req.FromID)
+                fleet.Set("to_id", req.ToID)
+                fleet.Set("eta", eta)
+                fleet.Set("strength", req.Strength)
 
 		if err := app.Dao().SaveRecord(fleet); err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{
@@ -124,10 +122,10 @@ func FleetOrderHandler(app *pocketbase.PocketBase) echo.HandlerFunc {
 			})
 		}
 
-		return c.JSON(http.StatusOK, map[string]interface{}{
-			"fleet_id": fleet.Id,
-			"eta_tick": etaTick,
-		})
+                return c.JSON(http.StatusOK, map[string]interface{}{
+                        "fleet_id": fleet.Id,
+                        "eta":     eta,
+                })
 	}
 }
 
@@ -288,10 +286,8 @@ func TradeOrderHandler(app *pocketbase.PocketBase) echo.HandlerFunc {
 			})
 		}
 
-		// Calculate first ETA (12 ticks travel time = 2 minutes at 6 ticks/minute)
-		currentTick := tick.GetCurrentTick(app)
-		travelTime := int64(12)
-		etaTick := currentTick + travelTime
+                // Calculate first ETA (2 minutes travel time)
+                eta := time.Now().Add(2 * time.Minute)
 
 		// Create trade route record
 		tradeCollection, err := app.Dao().FindCollectionByNameOrId("trade_routes")
@@ -306,8 +302,8 @@ func TradeOrderHandler(app *pocketbase.PocketBase) echo.HandlerFunc {
 		trade.Set("from_id", req.FromID)
 		trade.Set("to_id", req.ToID)
 		trade.Set("cargo", req.Cargo)
-		trade.Set("cap", req.Capacity)
-		trade.Set("eta_tick", etaTick)
+                trade.Set("cap", req.Capacity)
+                trade.Set("eta", eta)
 
 		if err := app.Dao().SaveRecord(trade); err != nil {
 			return c.JSON(http.StatusInternalServerError, map[string]string{
@@ -315,10 +311,10 @@ func TradeOrderHandler(app *pocketbase.PocketBase) echo.HandlerFunc {
 			})
 		}
 
-		return c.JSON(http.StatusOK, map[string]interface{}{
-			"trade_id": trade.Id,
-			"eta_tick": etaTick,
-		})
+                return c.JSON(http.StatusOK, map[string]interface{}{
+                        "trade_id": trade.Id,
+                        "eta":      eta,
+                })
 	}
 }
 

--- a/frontend/src/components/mapRenderer.js
+++ b/frontend/src/components/mapRenderer.js
@@ -417,14 +417,18 @@ export class MapRenderer {
 
   drawFleets(deltaTime) {
     this.fleets.forEach(fleet => {
-      // Calculate fleet position based on progress
+      // Calculate fleet position based on travel progress
       const fromSystem = this.systems.find(s => s.id === fleet.from_id);
       const toSystem = this.systems.find(s => s.id === fleet.to_id);
-      
+
       if (!fromSystem || !toSystem) return;
 
-      // TODO: Calculate actual progress based on ETA
-      const progress = 0.5; // Placeholder
+      // Progress is based on ETA timestamp
+      const travelTime = 2 * 60 * 1000; // 2 minutes in ms
+      const eta = new Date(fleet.eta).getTime();
+      let progress = 1 - (eta - Date.now()) / travelTime;
+      if (progress < 0) progress = 0;
+      if (progress > 1) progress = 1;
       const worldX = fromSystem.x + (toSystem.x - fromSystem.x) * progress;
       const worldY = fromSystem.y + (toSystem.y - fromSystem.y) * progress;
       
@@ -483,6 +487,7 @@ export class MapRenderer {
   setSelectedSystem(system) {
     this.selectedSystem = system;
   }
+
 
   // Center view on a specific system
   centerOnSystem(systemId) {

--- a/frontend/src/components/uiController.js
+++ b/frontend/src/components/uiController.js
@@ -329,7 +329,7 @@ export class UIController {
           <div>From: ${fleet.from_name || fleet.from_id}</div>
           <div>To: ${fleet.to_name || fleet.to_id}</div>
           <div>Strength: ${fleet.strength}</div>
-          <div>ETA: ${fleet.eta_tick ? `Tick ${fleet.eta_tick}` : 'Unknown'}</div>
+          <div>ETA: ${fleet.eta ? new Date(fleet.eta).toLocaleTimeString() : 'Unknown'}</div>
         </div>
       </div>
     `).join('') : '<div class="text-space-400">No fleets in transit</div>';
@@ -348,7 +348,7 @@ export class UIController {
           <div>To: ${trade.to_name || trade.to_id}</div>
           <div>Cargo: ${trade.cargo}</div>
           <div>Capacity: ${trade.cap}</div>
-          <div>ETA: ${trade.eta_tick ? `Tick ${trade.eta_tick}` : 'Unknown'}</div>
+          <div>ETA: ${trade.eta ? new Date(trade.eta).toLocaleTimeString() : 'Unknown'}</div>
         </div>
       </div>
     `).join('') : '<div class="text-space-400">No active trade routes</div>';


### PR DESCRIPTION
## Summary
- switch fleet and trade route ETA from tick-based to real timestamps
- animate fleets based on ETA time instead of tick count
- display human-readable ETA for fleets and trade routes

## Testing
- `npm run build` *(fails: vite not found)*
- `go vet ./...` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_683b0a6cd1c48324a775f889c81b1702