### PR TITLE
Implement building purchase API and UI

### DIFF
--- a/backend/pkg/api.go
+++ b/backend/pkg/api.go
@@ -27,6 +27,7 @@ func RegisterAPIRoutes(app *pocketbase.PocketBase) {
 		e.Router.GET("/api/systems/:id", getSystem(app))
 		e.Router.GET("/api/planets", getPlanets(app))
 		e.Router.GET("/api/buildings", getBuildings(app))
+		e.Router.GET("/api/building_types", getBuildingTypes(app))
 		e.Router.GET("/api/fleets", getFleets(app))
 		e.Router.GET("/api/trade_routes", getTradeRoutes(app))
 		e.Router.GET("/api/treaties", getTreaties(app))
@@ -94,6 +95,14 @@ type BuildingData struct {
 	Level          int    `json:"level"`
 	Active         bool   `json:"active"`
 	CreditsPerTick int    `json:"credits_per_tick"`
+}
+
+type BuildingTypeData struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Cost           int    `json:"cost"`
+	WorkerCapacity int    `json:"worker_capacity"`
+	MaxLevel       int    `json:"max_level"`
 }
 
 type FleetData struct {
@@ -399,6 +408,34 @@ func getBuildings(app *pocketbase.PocketBase) echo.HandlerFunc {
 			"perPage":    len(buildingsData),
 			"totalItems": len(buildingsData),
 			"items":      buildingsData,
+		})
+	}
+}
+
+// getBuildingTypes returns the available building types
+func getBuildingTypes(app *pocketbase.PocketBase) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		types, err := app.Dao().FindRecordsByExpr("building_types", nil, nil)
+		if err != nil {
+			return c.JSON(http.StatusInternalServerError, map[string]string{"error": "Failed to fetch building types"})
+		}
+
+		data := make([]BuildingTypeData, len(types))
+		for i, t := range types {
+			data[i] = BuildingTypeData{
+				ID:             t.Id,
+				Name:           t.GetString("name"),
+				Cost:           t.GetInt("cost"),
+				WorkerCapacity: t.GetInt("worker_capacity"),
+				MaxLevel:       t.GetInt("max_level"),
+			}
+		}
+
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"page":       1,
+			"perPage":    len(data),
+			"totalItems": len(data),
+			"items":      data,
 		})
 	}
 }

--- a/frontend/src/components/uiController.js
+++ b/frontend/src/components/uiController.js
@@ -360,57 +360,36 @@ export class UIController {
     );
   }
 
-  showBuildModal(system) {
-    const buildings = [
-      {
-        type: "habitat",
-        name: "Habitat",
-        cost: 100,
-        description: "Increases population capacity",
-      },
-      { type: "farm", name: "Farm", cost: 150, description: "Produces food" },
-      { type: "mine", name: "Mine", cost: 200, description: "Produces ore" },
-      {
-        type: "factory",
-        name: "Factory",
-        cost: 300,
-        description: "Produces goods",
-      },
-      {
-        type: "shipyard",
-        name: "Shipyard",
-        cost: 500,
-        description: "Enables fleet construction",
-      },
-      {
-        type: "bank",
-        name: "Bank",
-        cost: 1000,
-        description: "Generates 1 credit per tick",
-      },
-    ];
+  async showBuildModal(system) {
+    try {
+      const { gameData } = await import("../lib/pocketbase.js");
+      const result = await gameData.getBuildingTypes();
+      const buildings = result?.items || [];
 
-    const buildingOptions = buildings
-      .map(
-        (building) => `
+      const buildingOptions = buildings
+        .map(
+          (b) => `
       <button class="w-full p-3 bg-space-700 hover:bg-space-600 rounded mb-2 text-left"
-              onclick="window.gameState.queueBuilding('${system.id}', '${building.type}')">
-        <div class="font-semibold">${building.name}</div>
-        <div class="text-sm text-space-300">${building.description}</div>
-        <div class="text-sm text-green-400">Cost: ${building.cost} credits</div>
+              onclick="window.gameState.queueBuilding('${system.id}', '${b.id}')">
+        <div class="font-semibold">${b.name}</div>
+        <div class="text-sm text-green-400">Cost: ${b.cost} credits</div>
       </button>
     `,
-      )
-      .join("");
+        )
+        .join("");
 
-    this.showModal(
-      `Build in ${system.name || `System ${system.id.slice(-3)}`}`,
-      `
-      <div class="space-y-2">
-        ${buildingOptions}
-      </div>
-    `,
-    );
+      this.showModal(
+        `Build in ${system.name || `System ${system.id.slice(-3)}`}`,
+        `
+        <div class="space-y-2">
+          ${buildingOptions || '<div class="text-space-400">No building types available</div>'}
+        </div>
+      `,
+      );
+    } catch (error) {
+      console.error("Failed to load building types:", error);
+      this.showError("Failed to load building types");
+    }
   }
 
   showSendFleetModal(system) {

--- a/frontend/src/lib/pocketbase.js
+++ b/frontend/src/lib/pocketbase.js
@@ -338,6 +338,19 @@ export class GameDataManager {
     }
   }
 
+  async getBuildingTypes() {
+    try {
+      return await pb.send("/api/building_types", { method: "GET" });
+    } catch (error) {
+      try {
+        suppressAutoCancelError(error);
+      } catch (e) {
+        console.error("Failed to fetch building types:", e);
+      }
+      return { items: [] };
+    }
+  }
+
   async createTradeRoute(fromId, toId, cargo, capacity) {
     if (!pb.authStore.isValid) throw new Error("Not authenticated");
 


### PR DESCRIPTION
## Summary
- expose `/api/building_types` on the backend
- support fetching building types in the frontend
- update the build modal to load available buildings from the server

## Testing
- `gofmt -w backend/pkg/api.go`
- `npx prettier -w frontend/src/components/uiController.js frontend/src/lib/pocketbase.js`

------
https://chatgpt.com/codex/tasks/task_b_683b7c5cb2d8832498be2060ae895dd8